### PR TITLE
Retire deprecated 'tier' variable

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,59 +24,8 @@ jobs:
           terraform_version: 0.12.29
       #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-#     TODO: This step duplicates work done by the Makefile.
-#     - name: check terraform formatting
-#       id: fmt
-#       run: |
-#         terraform fmt -check -recursive
-
       - name: run make
       # env:
       #   TOKEN: ${{ secrets.TOKEN }}
         run: |
           make all
-
-#     - name: terraform init
-#       id: init
-#       run: terraform init
-#
-#      - name: terraform plan
-#        id: plan
-#        if: github.event_name == 'pull_request'
-#        run: terraform plan -no-color
-#        continue-on-error: true
-#
-#      - uses: actions/github-script@0.9.0
-#        if: github.event_name == 'pull_request'
-#        env:
-#          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          script: |
-#            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-#            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-#            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-#
-#            <details><summary>Show Plan</summary>
-#
-#            \`\`\`${process.env.PLAN}\`\`\`
-#
-#            </details>
-#
-#            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
-#
-#
-#            github.issues.createComment({
-#              issue_number: context.issue.number,
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              body: output
-#            })
-#
-#      - name: terraform plan status
-#        if: steps.plan.outcome == 'failure'
-#        run: exit 1
-#
-#      - name: terraform apply
-#        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-#        run: terraform apply -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPO := $(shell basename $(shell git remote get-url origin) .git)
 all: test
 
 test: .terraform
-	AWS_DEFAULT_REGION=us-east-2 terraform validate
+	terraform validate
 	terraform fmt -check
 	! egrep "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" *.tf README.md
 	# Do NOT put terraform-aws in the title

--- a/modules/get-subnets/README.md
+++ b/modules/get-subnets/README.md
@@ -35,8 +35,6 @@ The following arguments are supported:
 
 * `subnet_type` - (Optional) Type of subnet to look up (e.g., "campus", "private", "public"). This requires the networking to be built with a corresponding `SubnetType` tag (note capitalization).
 
-* `tier` - (Optional) Has same meaning as `subnet_type`, but using this name is Deprecated. This argument remains to support legacy service deployments until they have been migrated to use `subnet_type`. **NOTE: This argument is deprecated in favor of `subnet_type`.**
-
 * `vpc` - (Required) Name of Virtual Private Cloud (VPC) from which the subnet IDs are to be looked up.
 
 Attributes Reference
@@ -47,7 +45,7 @@ The following attributes are exported:
 * `subnet_detail` – If `include_subnet_detail` is `true`, this attribute's value is the [`aws_subnet`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) object for the selected subnets. The returned object's keys are the subnet IDs of the selected subnets. If `include_subnet_detail` is `false`, the returned attribute value is `null`.
 
 * `subnets` – object describing subnet(s) matching the specified `subnet_type` on the virtual private cloud (VPC) specified by the `vpc` argument. In the absence of a `subnet_type` argument, list of all subnets for the VPC specified by the `vpc` argument.
-**NOTE:** If neither `subnet_type` nor `tier` matches the tags on any subnet, an empty list is returned.
+**NOTE:** If no subnet has a `SubnetType` tag corresponding to the specified `subnet_type`, an empty list is returned.
 
 * `subnets_by_az` – If `include_subnets_by_az` is `true`, this attribute's value is a map whose keys are the availability zones (AZs) of the selected subnets. The value stored under each key is a list of subnet IDs corresponding to that AZ. If `include_subnets_by_az` is ``false`, this attribute's value is `null`.
 

--- a/modules/get-subnets/main.tf
+++ b/modules/get-subnets/main.tf
@@ -1,9 +1,5 @@
-# TODO: Remove local variable and replace local.subnet_type with
-# var.subnet_type elsewhere once 'tier' is deprecated.
-
 locals {
   need_subnet_detail = (var.include_subnet_detail || var.include_subnets_by_az)
-  subnet_type        = can(coalesce(var.subnet_type, var.tier)) ? coalesce(var.subnet_type, var.tier) : null
 }
 
 data "aws_vpc" "selected" {
@@ -19,7 +15,7 @@ data "aws_subnets" "selected" {
   }
 
   # SubnetType filter only applies if caller specifies subnet_type argument.
-  tags = local.subnet_type != null ? { SubnetType = local.subnet_type } : {}
+  tags = var.subnet_type != null ? { SubnetType = var.subnet_type } : null
 }
 
 data "aws_subnet" "selected" {

--- a/modules/get-subnets/outputs.tf
+++ b/modules/get-subnets/outputs.tf
@@ -16,17 +16,8 @@ output "vpc" {
 
 # Debug-only variables.
 
-# TODO: Remove this variable once 'tier' is deprecated.
-output "_coalesced_subnet_type" {
-  value = (var._debug) ? local.subnet_type : null
-}
-
 output "_subnet_type" {
   value = (var._debug) ? var.subnet_type : null
-}
-
-output "_tier" {
-  value = (var._debug) ? var.tier : null
 }
 
 output "_vpc" {

--- a/modules/get-subnets/variables.tf
+++ b/modules/get-subnets/variables.tf
@@ -12,19 +12,19 @@ variable "include_subnets_by_az" {
 
 variable "subnet_type" {
   description = "Type of subnet to look up (e.g., 'campus', 'private', 'public')"
-  # TODO: Remove default once 'tier' is deprecated.
-  default = ""
+  default     = null
 }
 
-variable "tier" {
-  description = "Deprecated argument; meaning is identical to `subnet_type` and is superseded by any value there"
-  default     = ""
+# TODO: The 'tier' variable has been retired; remove in the future.
 
-  # TODO: Uncomment validation once 'tier' is deprecated, or remove variable.
-  # validation {
-  #   condition     = var.tier == ""
-  #   error_message = "ERROR: 'tier' argument is deprecated; use 'subnet_type' instead."
-  # }
+variable "tier" {
+  description = "Deprecated variable; use `subnet_type` instead"
+  default     = null
+
+  validation {
+    condition     = var.tier == null || var.tier == ""
+    error_message = "ERROR: 'tier' argument has been retired; use 'subnet_type' instead."
+  }
 }
 
 variable "vpc" {


### PR DESCRIPTION
The 'tier' variable has been replaced by 'subnet_type'. It remains in variables.tf solely to produce an error message if specified. Remove the 'tier' variable in the future.